### PR TITLE
move informer event handlers to networking api group

### DIFF
--- a/provider/kubernetes/client.go
+++ b/provider/kubernetes/client.go
@@ -127,7 +127,7 @@ func (c *clientImpl) WatchAll(namespaces Namespaces, stopCh <-chan struct{}) (<-
 	eventHandler := c.newResourceEventHandler(eventCh)
 	for _, ns := range namespaces {
 		factory := informers.NewFilteredSharedInformerFactory(c.clientset, resyncPeriod, ns, nil)
-		factory.Extensions().V1beta1().Ingresses().Informer().AddEventHandler(eventHandler)
+		factory.Networking().V1().Ingresses().Informer().AddEventHandler(eventHandler)
 		factory.Core().V1().Services().Informer().AddEventHandler(eventHandler)
 		factory.Core().V1().Endpoints().Informer().AddEventHandler(eventHandler)
 		c.factories[ns] = factory


### PR DESCRIPTION
This updates the event handlers for the informers to use the networking group for handling ingress events. This fixes the issue where the new version would list ingresses on the extensions api group while performing watches on the networking group. 

